### PR TITLE
Fix minimap jumps

### DIFF
--- a/src/NewWorldMinimap/MapForm.cs
+++ b/src/NewWorldMinimap/MapForm.cs
@@ -99,6 +99,8 @@ namespace NewWorldMinimap
         {
             Stopwatch sw = new Stopwatch();
 
+            Vector3 lastPos = Vector3.Zero;
+            int jumpThreshold = int.MaxValue;
             int i = 0;
             while (true)
             {
@@ -106,7 +108,23 @@ namespace NewWorldMinimap
 
                 if (pd.TryGetPosition(ScreenGrabber.TakeScreenshot(), out Vector3 pos))
                 {
-                    Console.WriteLine($"{i}: {pos}");
+                    Vector3 difference = lastPos - pos;
+                    Console.WriteLine($"{i}: {pos} [{difference.Length()}]");
+                    if (difference.Length() > 20.0)
+                    {
+                        if (jumpThreshold < 3)
+                        {
+                            Console.WriteLine($"{i}: Failure due to jump of {difference.Length()}");
+                            jumpThreshold++;
+                            continue;
+                        }
+                        else
+                        {
+                            jumpThreshold = 0;
+                        }
+                    }
+
+                    lastPos = pos;
                     using Image<Rgba32> baseMap = map.GetTileForCoordinate(pos.X, pos.Y);
 
                     (int imageX, int imageY) = map.ToMinimapCoordinate(pos.X, pos.Y, pos.X, pos.Y);


### PR DESCRIPTION
Added a check for minimap jumps, when the player moves too far away from the last position.

The behaviour is really simple: check the distance between the last position and the newer, if its too long it won't update it.

The position is updated anyway if the threshold of `3` wrong positions is triggered. The default jump tolerance is `20`.


_PS. Teleports work, the player position is **always** updated after at least 3 tries._