### PR TITLE
Flag program as DPI aware

### DIFF
--- a/src/NewWorldMinimap/Program.cs
+++ b/src/NewWorldMinimap/Program.cs
@@ -8,6 +8,10 @@ namespace NewWorldMinimap
     /// </summary>
     public static class Program
     {
+        //https://stackoverflow.com/questions/32438736/taking-a-screenshot-using-graphics-copyfromscreen-with-150-scaling/37800963
+        [System.Runtime.InteropServices.DllImport("user32.dll")]
+        public static extern bool SetProcessDPIAware();
+
         /// <summary>
         /// Defines the entry point of the application.
         /// </summary>
@@ -15,6 +19,7 @@ namespace NewWorldMinimap
         [STAThread]
         public static void Main(string[] args)
         {
+            SetProcessDPIAware();
             Application.EnableVisualStyles();
             using Form map = new MapForm();
             Application.Run(map);

--- a/src/NewWorldMinimap/Program.cs
+++ b/src/NewWorldMinimap/Program.cs
@@ -8,10 +8,6 @@ namespace NewWorldMinimap
     /// </summary>
     public static class Program
     {
-        //https://stackoverflow.com/questions/32438736/taking-a-screenshot-using-graphics-copyfromscreen-with-150-scaling/37800963
-        [System.Runtime.InteropServices.DllImport("user32.dll")]
-        public static extern bool SetProcessDPIAware();
-
         /// <summary>
         /// Defines the entry point of the application.
         /// </summary>
@@ -24,5 +20,8 @@ namespace NewWorldMinimap
             using Form map = new MapForm();
             Application.Run(map);
         }
+
+        [System.Runtime.InteropServices.DllImport("user32")]
+        private static extern bool SetProcessDPIAware();
     }
 }


### PR DESCRIPTION
This will allow successful capture on high-DPI monitors, by setting the program as DPI Aware and let it read out raw resolution instead of DPI transformed resolution.