### PR TITLE
Enable TLS 1.2-based connections explicitly

### DIFF
--- a/src/NewWorldMinimap/Program.cs
+++ b/src/NewWorldMinimap/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
@@ -14,6 +15,7 @@ namespace NewWorldMinimap
         /// Defines the entry point of the application.
         /// </summary>
         [STAThread]
+        [SuppressMessage("Security", "CA5386:Avoid hardcoding SecurityProtocolType value", Justification = "See comment below.")]
         public static void Main()
         {
             // Explicitly add TLS 1.2 to the list of protocols that can be used. On some older systems, most notably Windows 7,

--- a/src/NewWorldMinimap/Program.cs
+++ b/src/NewWorldMinimap/Program.cs
@@ -24,7 +24,7 @@ namespace NewWorldMinimap
             // the `|=` operator.
             // This line should be removed if we decide to not support older systems, or when TLS 1.2 is no longer supported by
             // the service.
-            ServicePointManager.SecurityProtocol |= System.Net.SecurityProtocolType.Tls12;
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 
             NativeMethods.SetProcessDPIAware();
             Application.EnableVisualStyles();

--- a/src/NewWorldMinimap/Program.cs
+++ b/src/NewWorldMinimap/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
@@ -13,7 +14,6 @@ namespace NewWorldMinimap
         /// Defines the entry point of the application.
         /// </summary>
         [STAThread]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Security", "CA5386:Avoid hardcoding SecurityProtocolType value", Justification = "See comment below.")]
         public static void Main()
         {
             // Explicitly add TLS 1.2 to the list of protocols that can be used. On some older systems, most notably Windows 7,
@@ -24,7 +24,7 @@ namespace NewWorldMinimap
             // the `|=` operator.
             // This line should be removed if we decide to not support older systems, or when TLS 1.2 is no longer supported by
             // the service.
-            System.Net.ServicePointManager.SecurityProtocol |= System.Net.SecurityProtocolType.Tls12;
+            ServicePointManager.SecurityProtocol |= System.Net.SecurityProtocolType.Tls12;
 
             NativeMethods.SetProcessDPIAware();
             Application.EnableVisualStyles();

--- a/src/NewWorldMinimap/Program.cs
+++ b/src/NewWorldMinimap/Program.cs
@@ -13,8 +13,19 @@ namespace NewWorldMinimap
         /// Defines the entry point of the application.
         /// </summary>
         [STAThread]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Security", "CA5386:Avoid hardcoding SecurityProtocolType value", Justification = "See comment below.")]
         public static void Main()
         {
+            // Explicitly add TLS 1.2 to the list of protocols that can be used. On some older systems, most notably Windows 7,
+            // older versions of the protocol are used. This causes an error when establishing the SSL/TLS connection with the
+            // map service, which disallows such (insecure) connections. By adding it here, the protocol may be selected during
+            // handshake negotiations, preventing the error from occurring.
+            // Note that we are *adding* the protocol as an eligible selection, not replacing any defaults. This is done using
+            // the `|=` operator.
+            // This line should be removed if we decide to not support older systems, or when TLS 1.2 is no longer supported by
+            // the service.
+            System.Net.ServicePointManager.SecurityProtocol |= System.Net.SecurityProtocolType.Tls12;
+
             NativeMethods.SetProcessDPIAware();
             Application.EnableVisualStyles();
             using Form map = new MapForm();


### PR DESCRIPTION
On some older systems older versions of the protocol are used.
By adding TLS 1.2 explicitly, negotiation errors can be prevented.