### PR TITLE
Make nullable extra player data

### DIFF
--- a/overwolf/src/Global.d.ts
+++ b/overwolf/src/Global.d.ts
@@ -46,7 +46,7 @@ declare type PlayerData = {
     position: Vector3,
     rotation: Vector3,
     compass: string,
-    map: string,
-    name: string,
-    world: string,
+    map: string | null,
+    name: string | null,
+    world: string | null,
 }

--- a/overwolf/src/Global.d.ts
+++ b/overwolf/src/Global.d.ts
@@ -46,7 +46,7 @@ declare type PlayerData = {
     position: Vector3,
     rotation: Vector3,
     compass: string,
-    map: string | null,
-    name: string | null,
-    world: string | null,
+    map: string | undefined,
+    name: string | undefined,
+    world: string | undefined,
 }

--- a/overwolf/src/logic/hooks.ts
+++ b/overwolf/src/logic/hooks.ts
@@ -38,10 +38,7 @@ function transformData(info: any): PlayerData | undefined {
         info = info.res.game_info;
     }
 
-    if (!info.location
-        || !info.map
-        || !info.player_name
-        || !info.world_name) {
+    if (!info.location) {
         console.error('Unsuccesful poll attempt!');
         console.error(info);
         return undefined;
@@ -68,9 +65,9 @@ function transformData(info: any): PlayerData | undefined {
         position,
         rotation,
         compass,
-        map: (info.map as string).trim(),
-        name: (info.player_name as string).trim(),
-        world: (info.world_name as string).trim(),
+        map: info.map ? (info.map as string).trim() : null,
+        name: info.player_name ? (info.player_name as string).trim() : null,
+        world: info.world_name ? (info.world_name as string).trim() : null,
     };
 }
 

--- a/overwolf/src/logic/hooks.ts
+++ b/overwolf/src/logic/hooks.ts
@@ -65,9 +65,9 @@ function transformData(info: any): PlayerData | undefined {
         position,
         rotation,
         compass,
-        map: info.map ? (info.map as string).trim() : null,
-        name: info.player_name ? (info.player_name as string).trim() : null,
-        world: info.world_name ? (info.world_name as string).trim() : null,
+        map: info.map ? (info.map as string).trim() : undefined,
+        name: info.player_name ? (info.player_name as string).trim() : undefined,
+        world: info.world_name ? (info.world_name as string).trim() : undefined,
     };
 }
 


### PR DESCRIPTION
For unknown reasons sometime the data received from Overwolf API does not contain `map`, `name` and `world` data.

They are currently not used in the minimap so I made that you can still fetch only the player location. If the data contains those 3 parts, they will be fetched.