### PR TITLE
Revert "Handle rotation with in game API"

### DIFF
--- a/overwolf/src/Minimap.tsx
+++ b/overwolf/src/Minimap.tsx
@@ -38,7 +38,7 @@ export default function Minimap(props: IProps) {
     const { classes } = useStyles();
 
     const [currentPosition, setCurrentPosition] = useState<Vector2>(debugLocations.default);
-    const [currentRotation, setCurrentRotation] = useState<number>(0);
+    const [lastPosition, setLastPosition] = useState<Vector2>(currentPosition);
     const canvas = useRef<HTMLCanvasElement>(null);
 
     const lastDraw = useRef(0);
@@ -54,7 +54,7 @@ export default function Minimap(props: IProps) {
         const currentDraw = Date.now();
         lastDraw.current = currentDraw;
 
-        const angle = -currentRotation * Math.PI / 180;
+        const angle = Math.atan2(currentPosition.x - lastPosition.x, currentPosition.y - lastPosition.y);
         const zoomLevel = appContext.value.zoomLevel;
         const renderAsCompass = appContext.value.compassMode && (appContext.isTransparentSurface ?? false);
 
@@ -190,13 +190,13 @@ export default function Minimap(props: IProps) {
         drawRef.current();
     }
 
-    function setPosition(pos: Vector2, rot: number) {
-        if (pos.x === currentPosition.x && pos.y === currentPosition.y && rot === currentRotation) {
+    function setPosition(pos: Vector2) {
+        if (pos.x === currentPosition.x && pos.y === currentPosition.y) {
             return;
         }
 
+        setLastPosition(currentPosition);
         setCurrentPosition(pos);
-        setCurrentRotation(rot);
     }
 
     useEffect(() => {
@@ -211,7 +211,7 @@ export default function Minimap(props: IProps) {
         window.addEventListener('resize', redraw);
 
         const callbackUnregister = registerEventCallback(info => {
-            setPosition(info.position, info.rotation.z);
+            setPosition(info.position);
         });
 
         return function () {

--- a/overwolf/src/logic/hooks.ts
+++ b/overwolf/src/logic/hooks.ts
@@ -55,7 +55,7 @@ function transformData(info: any): PlayerData | undefined {
     const rotation = {
         x: parseFloat(locationParts[7]),
         y: parseFloat(locationParts[9]),
-        z: parseFloat(locationParts[11]) - 90, // OW North is 90
+        z: parseFloat(locationParts[11]),
     };
 
     const compass = locationParts[13].trim();


### PR DESCRIPTION
Reverts CptWesley/NewWorldMinimap#57

The expected outcome should be the same as the old behaviour, however the API currently updates the rotation 1 tick later than the corresponding position update, thus the behaviour is slightly less fluent.