### PR TITLE
Add hotkeys for zooming, mouse wheel scroll zooming

### DIFF
--- a/overwolf/public/manifest.json
+++ b/overwolf/public/manifest.json
@@ -86,12 +86,12 @@
       },
       "zoomIn": {
         "title": "Zoom in (in-game only)",
-        "action-type": "toggle",
+        "action-type": "custom",
         "default": "Ctrl+["
       },
       "zoomOut": {
         "title": "Zoom out (in-game only)",
-        "action-type": "toggle",
+        "action-type": "custom",
         "default": "Ctrl+]"
       }
     },

--- a/overwolf/public/manifest.json
+++ b/overwolf/public/manifest.json
@@ -83,6 +83,16 @@
         "title": "Show/Hide In-Game Window",
         "action-type": "toggle",
         "default": "Ctrl+F"
+      },
+      "zoomIn": {
+        "title": "Zoom in (in-game only)",
+        "action-type": "toggle",
+        "default": "Ctrl+["
+      },
+      "zoomOut": {
+        "title": "Zoom out (in-game only)",
+        "action-type": "toggle",
+        "default": "Ctrl+]"
       }
     },
     "protocol_override_domains": {

--- a/overwolf/src/Desktop.tsx
+++ b/overwolf/src/Desktop.tsx
@@ -5,6 +5,5 @@ import Frame from './Frame';
 export default function Desktop() {
     return <Frame
         header={<DesktopHeader />}
-        minimapWindowType='desktop'
     />;
 }

--- a/overwolf/src/Frame.tsx
+++ b/overwolf/src/Frame.tsx
@@ -4,7 +4,7 @@ import produce from 'immer';
 import React, { useCallback, useEffect, useState } from 'react';
 import { GlobalStyles } from 'tss-react';
 import App from './App';
-import { AppContext, AppContextSettings, IAppContext, loadAppContextSettings, MinimapWindowType } from './contexts/AppContext';
+import { AppContext, AppContextSettings, IAppContext, loadAppContextSettings } from './contexts/AppContext';
 import FrameMenu from './FrameMenu';
 import { deconstructIconStorageKey, getStorageKeyScope, load, loadIconCategory, loadIconType, scopedSettings, simpleStorageDefaultSettings, SimpleStorageSetting } from './logic/storage';
 import { getBackgroundController } from './OverwolfWindows/background/background';
@@ -12,7 +12,6 @@ import { makeStyles, theme } from './theme';
 
 interface IProps {
     header: React.ReactNode;
-    minimapWindowType: MinimapWindowType;
     isTransparentSurface?: boolean;
 }
 
@@ -40,7 +39,6 @@ export default function Frame(props: IProps) {
     const {
         header,
         isTransparentSurface,
-        minimapWindowType,
     } = props;
     const { classes } = useStyles();
 
@@ -105,7 +103,6 @@ export default function Frame(props: IProps) {
         toggleFrameMenu,
         gameRunning,
         isTransparentSurface,
-        minimapWindowType,
         frameMenuVisible,
     };
 

--- a/overwolf/src/FrameMenu.tsx
+++ b/overwolf/src/FrameMenu.tsx
@@ -4,7 +4,7 @@ import React, { useContext } from 'react';
 import { AppContext } from './contexts/AppContext';
 import { globalLayers } from './globalLayers';
 import ReturnIcon from './Icons/ReturnIcon';
-import { SimpleStorageSetting, store, storeIconCategory, storeIconType } from './logic/storage';
+import { SimpleStorageSetting, store, storeIconCategory, storeIconType, zoomLevelSettingBounds } from './logic/storage';
 import { compareNames } from './logic/util';
 import { makeStyles } from './theme';
 
@@ -244,12 +244,12 @@ export default function FrameMenu(props: IProps) {
                         <label className={classes.range}>
                             <input
                                 type='range'
-                                value={7 - context.settings.zoomLevel}
+                                value={zoomLevelSettingBounds[1] - context.settings.zoomLevel}
                                 min='0'
-                                max='6.5'
+                                max={zoomLevelSettingBounds[1] - zoomLevelSettingBounds[0]}
                                 step='0.1'
                                 onChange={e => {
-                                    const newValue = 7 - e.currentTarget.valueAsNumber;
+                                    const newValue = zoomLevelSettingBounds[1] - e.currentTarget.valueAsNumber;
                                     updateSimpleSetting('zoomLevel', newValue);
                                 }}
                             />

--- a/overwolf/src/InGame.tsx
+++ b/overwolf/src/InGame.tsx
@@ -5,7 +5,6 @@ import InGameHeader from './InGameHeader';
 export default function Desktop() {
     return <Frame
         header={<InGameHeader />}
-        minimapWindowType='inGame'
         isTransparentSurface
     />;
 }

--- a/overwolf/src/InGameHeader.tsx
+++ b/overwolf/src/InGameHeader.tsx
@@ -6,6 +6,7 @@ import { globalLayers } from './globalLayers';
 import CloseIcon from './Icons/CloseIcon';
 import DesktopWindowIcon from './Icons/DesktopWindowIcon';
 import SettingsIcon from './Icons/SettingsIcon';
+import { getHotkeyManager } from './logic/hotkeyManager';
 import { getBackgroundController } from './OverwolfWindows/background/background';
 import { hotkeys, newWorldId, windowNames } from './OverwolfWindows/consts';
 import { inGameAppTitle } from './OverwolfWindows/in_game/in_game';
@@ -148,6 +149,7 @@ const useStyles = makeStyles()(theme => ({
 }));
 
 const backgroundController = getBackgroundController();
+const hotkeyManager = getHotkeyManager();
 export default function InGameHeader() {
     const context = useContext(AppContext);
     const { classes } = useStyles();
@@ -156,9 +158,9 @@ export default function InGameHeader() {
     });
     const [inGameWindowId, setInGameWindowId] = useState<string>();
     const useTransparency = context.settings.transparentHeader && context.gameRunning && !context.frameMenuVisible;
-    const [hotkeyText, setHotkeyText] = useState<string>();
 
     const draggable = useRef<HTMLDivElement | null>(null);
+    const hotkeyText = hotkeyManager.getHotkeyText('toggleInGame');
 
     useEffect(() => {
         overwolf.windows.getCurrentWindow(windowResult => {
@@ -167,7 +169,7 @@ export default function InGameHeader() {
             }
         });
 
-        OWHotkeys.onHotkeyDown(hotkeys.toggleInGame, async function () {
+        return hotkeyManager.registerHotkey('toggleInGame', async function () {
             const inGameState = await inGameWindow.getWindowState();
 
             if (inGameState.window_state === WindowState.NORMAL || inGameState.window_state === WindowState.MAXIMIZED) {
@@ -175,10 +177,6 @@ export default function InGameHeader() {
             } else if (inGameState.window_state === WindowState.MINIMIZED || inGameState.window_state === WindowState.CLOSED) {
                 backgroundController.openWindow('inGame');
             }
-        });
-
-        OWHotkeys.getHotkeyText(hotkeys.toggleInGame, newWorldId).then(hotkeyText => {
-            setHotkeyText(hotkeyText);
         });
     }, []);
 

--- a/overwolf/src/Minimap.tsx
+++ b/overwolf/src/Minimap.tsx
@@ -263,11 +263,15 @@ export default function Minimap(props: IProps) {
         };
     }, []);
 
-    useEffect(() => {
-        const zoomInRegistration = hotkeyManager.registerHotkey('zoomIn', () => zoomBy(appContext.settings.zoomLevel / 5));
-        const zoomOutRegistration = hotkeyManager.registerHotkey('zoomOut', () => zoomBy(appContext.settings.zoomLevel / -5));
-        return () => { zoomInRegistration(); zoomOutRegistration(); };
-    }, [appContext.settings.zoomLevel]);
+    if (NWMM_APP_WINDOW === 'inGame') {
+        // This is alright, because the app window descriptor does not change.
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        useEffect(() => {
+            const zoomInRegistration = hotkeyManager.registerHotkey('zoomIn', () => zoomBy(appContext.settings.zoomLevel / 5));
+            const zoomOutRegistration = hotkeyManager.registerHotkey('zoomOut', () => zoomBy(appContext.settings.zoomLevel / -5));
+            return () => { zoomInRegistration(); zoomOutRegistration(); };
+        }, [appContext.settings.zoomLevel]);
+    }
 
     useEffect(() => {
         // Expose the setPosition and getMarkers window on the global Window object

--- a/overwolf/src/Minimap.tsx
+++ b/overwolf/src/Minimap.tsx
@@ -6,6 +6,7 @@ import { registerEventCallback } from './logic/hooks';
 import { getIcon, GetPlayerIcon, setIconScale } from './logic/icons';
 import { getMapTiles } from './logic/map';
 import { getMarkers } from './logic/markers';
+import { store, zoomLevelSettingBounds } from './logic/storage';
 import { getTileCache } from './logic/tileCache';
 import { getTileMarkerCache } from './logic/tileMarkerCache';
 import { toMinimapCoordinate } from './logic/tiles';
@@ -221,6 +222,21 @@ export default function Minimap(props: IProps) {
         setCurrentPosition(pos);
     }
 
+    function zoomBy(delta: number) {
+        const nextZoomLevel = Math.max(
+            zoomLevelSettingBounds[0],
+            Math.min(
+                zoomLevelSettingBounds[1],
+                appContext.settings.zoomLevel + delta));
+        appContext.update({ zoomLevel: nextZoomLevel });
+        store('zoomLevel', nextZoomLevel);
+    }
+
+    function handleWheel(e: React.WheelEvent<HTMLCanvasElement>) {
+        console.log(e.deltaY);
+        zoomBy(Math.sign(e.deltaY) * appContext.settings.zoomLevel / 5 * Math.abs(e.deltaY) / 100);
+    }
+
     useEffect(() => {
         redraw();
     }, [currentPosition, appContext]);
@@ -267,6 +283,7 @@ export default function Minimap(props: IProps) {
             ref={canvas}
             className={clsx(classes.canvas)}
             style={dynamicStyling}
+            onWheel={handleWheel}
         />
         <div className={classes.cacheStatus}>
             {tilesDownloading > 0 &&

--- a/overwolf/src/Minimap.tsx
+++ b/overwolf/src/Minimap.tsx
@@ -3,6 +3,7 @@ import React, { useContext, useEffect, useRef, useState } from 'react';
 import { AppContext } from './contexts/AppContext';
 import { globalLayers } from './globalLayers';
 import { registerEventCallback } from './logic/hooks';
+import { getHotkeyManager } from './logic/hotkeyManager';
 import { getIcon, GetPlayerIcon, setIconScale } from './logic/icons';
 import { getMapTiles } from './logic/map';
 import { getMarkers } from './logic/markers';
@@ -49,6 +50,7 @@ const useStyles = makeStyles()({
 const tileCache = getTileCache();
 const markerCache = getTileMarkerCache();
 
+const hotkeyManager = getHotkeyManager();
 export default function Minimap(props: IProps) {
     const {
         className,
@@ -260,6 +262,12 @@ export default function Minimap(props: IProps) {
             markerRegistration();
         };
     }, []);
+
+    useEffect(() => {
+        const zoomInRegistration = hotkeyManager.registerHotkey('zoomIn', () => zoomBy(appContext.settings.zoomLevel / 5));
+        const zoomOutRegistration = hotkeyManager.registerHotkey('zoomOut', () => zoomBy(appContext.settings.zoomLevel / -5));
+        return () => { zoomInRegistration(); zoomOutRegistration(); };
+    }, [appContext.settings.zoomLevel]);
 
     useEffect(() => {
         // Expose the setPosition and getMarkers window on the global Window object

--- a/overwolf/src/OverwolfWindows/background/background.ts
+++ b/overwolf/src/OverwolfWindows/background/background.ts
@@ -1,4 +1,5 @@
 import { OWGameListener, OWGames, OWWindow } from '@overwolf/overwolf-api-ts';
+import { initializeHotkeyManager } from '../../logic/hotkeyManager';
 import { initializeTileCache } from '../../logic/tileCache';
 import { initializeTileMarkerCache } from '../../logic/tileMarkerCache';
 import { BackgroundWindow, ConcreteWindow, newWorldId, windowNames } from '../consts';
@@ -156,3 +157,4 @@ if (BackgroundController.isSupported) {
 
 initializeTileCache();
 initializeTileMarkerCache();
+initializeHotkeyManager();

--- a/overwolf/src/OverwolfWindows/consts.ts
+++ b/overwolf/src/OverwolfWindows/consts.ts
@@ -15,6 +15,8 @@ export type ConcreteWindow = Exclude<keyof typeof windowNames, BackgroundWindow>
 
 const hotkeys = {
     toggleInGame: 'showhide',
+    zoomIn: 'zoomIn',
+    zoomOut: 'zoomOut',
 } as const;
 
 export {

--- a/overwolf/src/contexts/AppContext.tsx
+++ b/overwolf/src/contexts/AppContext.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { load, simpleStorageDefaultSettings, SimpleStorageSetting } from '../logic/storage';
 
-export type MinimapWindowType = 'desktop' | 'inGame';
-
 export type AppContextSettings = SimpleStorageSetting & {
     iconSettings: IconSettings | undefined;
 }
@@ -13,7 +11,6 @@ export interface IAppContext {
     toggleFrameMenu: () => void;
     gameRunning: boolean;
     isTransparentSurface: boolean | undefined;
-    minimapWindowType: MinimapWindowType | undefined;
     frameMenuVisible: boolean;
 }
 
@@ -42,7 +39,6 @@ export const defaultAppContext: IAppContext = {
     toggleFrameMenu: () => { },
     gameRunning: false,
     isTransparentSurface: undefined,
-    minimapWindowType: undefined,
     frameMenuVisible: false,
 };
 

--- a/overwolf/src/logic/hotkeyManager.ts
+++ b/overwolf/src/logic/hotkeyManager.ts
@@ -1,0 +1,73 @@
+import { OWHotkeys } from '@overwolf/overwolf-api-ts/dist';
+import { hotkeys, newWorldId } from '../OverwolfWindows/consts';
+
+export type HotkeyManagerWindow = typeof window & {
+    NWMM_HotkeyManager: HotkeyManager;
+}
+
+type Hotkey = keyof typeof hotkeys;
+type OnHotkeyInvokedListener = (hotkeyResult: overwolf.settings.hotkeys.OnPressedEvent) => void;
+
+class HotkeyManager {
+    private static _instance: HotkeyManager;
+    private hotkeyListeners: Readonly<Record<Hotkey, Set<OnHotkeyInvokedListener>>>;
+    private hotkeyTexts: Map<Hotkey, string>;
+
+    constructor() {
+        this.hotkeyListeners = {
+            toggleInGame: new Set(),
+            zoomIn: new Set(),
+            zoomOut: new Set(),
+        };
+        this.hotkeyTexts = new Map();
+
+        for (const [key, overwolfBindName] of Object.entries(hotkeys)) {
+            const hotkeyKey = key as Hotkey;
+
+            OWHotkeys.onHotkeyDown(overwolfBindName, (hotkeyResult: overwolf.settings.hotkeys.OnPressedEvent) => {
+                this.hotkeyListeners[hotkeyKey].forEach(l => {
+                    l(hotkeyResult);
+                });
+            });
+
+            OWHotkeys.getHotkeyText(hotkeys.toggleInGame, newWorldId).then(hotkeyText => {
+                this.hotkeyTexts.set(hotkeyKey, hotkeyText);
+            });
+        }
+    }
+
+    public static get isSupported() {
+        return NWMM_APP_WINDOW === 'background';
+    }
+
+    public static get instance(): HotkeyManager {
+        if (!this.isSupported) {
+            throw new Error('Using HotkeyManager directly in this window is not supported. Use getHotkeyManager instead.');
+        }
+
+        if (!HotkeyManager._instance) {
+            HotkeyManager._instance = new HotkeyManager();
+        }
+
+        return HotkeyManager._instance;
+    }
+
+    public registerHotkey = (hotkey: Hotkey, listener: OnHotkeyInvokedListener) => {
+        this.hotkeyListeners[hotkey].add(listener);
+        return () => {
+            this.hotkeyListeners[hotkey].delete(listener);
+        };
+    }
+
+    public getHotkeyText = (hotkey: Hotkey) => this.hotkeyTexts.get(hotkey);
+}
+
+export function initializeHotkeyManager() {
+    if (HotkeyManager.isSupported) {
+        (window as HotkeyManagerWindow).NWMM_HotkeyManager = HotkeyManager.instance;
+    }
+}
+
+export function getHotkeyManager() {
+    return (overwolf.windows.getMainWindow() as HotkeyManagerWindow).NWMM_HotkeyManager;
+}

--- a/overwolf/src/logic/storage.ts
+++ b/overwolf/src/logic/storage.ts
@@ -30,6 +30,8 @@ export type KnownStorageScope = ConcreteWindow | typeof iconSettingStorageScope;
 export const knownStorageScopes: KnownStorageScope[] = ['desktop', 'icon', 'inGame'];
 const defaultHiddenIconCategories = ['npc', 'pois'];
 
+export const zoomLevelSettingBounds = [0.5, 7] as const;
+
 /** Stores a simple storage setting. A scope will be added to the key, if the setting is a scoped setting. */
 export function store<TKey extends keyof SimpleStorageSetting>(key: TKey, value: SimpleStorageSetting[TKey]) {
     let storageKey: string = key;


### PR DESCRIPTION
- Adds a global hotkey manager to prevent leaks
- Add mouse wheel scrolling
- Add zoom by hotkeys
  - This only works in the in-game window. It is guarded with an if-statement around a `useEffect` hook. This is normally a bad thing and should be avoided, but in this case it is OK, because the result of the condition never changes over the lifetime of the component.