### PR TITLE
Stop leaking global listeners

### DIFF
--- a/overwolf/src/Minimap.tsx
+++ b/overwolf/src/Minimap.tsx
@@ -305,7 +305,8 @@ export default function Minimap(props: IProps) {
         (window as any).setPosition = setPosition;
         (window as any).getMarkers = getMarkers;
 
-        window.addEventListener('resize', () => redraw(true));
+        const onResize = () => redraw(true);
+        window.addEventListener('resize', onResize);
 
         const callbackUnregister = registerEventCallback(info => {
             setPosition(info.position);
@@ -315,7 +316,7 @@ export default function Minimap(props: IProps) {
         const interval = interpolationEnabled ? setInterval(() => redraw(false), 100) : -1;
 
         return function () {
-            window.removeEventListener('resize', () => redraw(true));
+            window.removeEventListener('resize', onResize);
             callbackUnregister();
             if (interpolationEnabled) {
                 clearInterval(interval);


### PR DESCRIPTION
The `resize` event listener seems to be leaking - see attached image. Left is cropped screenshot of devtools before the change, the right is after.

![image](https://user-images.githubusercontent.com/8895126/137589371-b6f90b74-59f4-45d6-ba5c-a882185be0be.png)
