### PR TITLE
Revert "Change hooks to be set globally" - change was causing map not to update while moving.

### DIFF
--- a/overwolf/src/OverwolfWindows/background/background.ts
+++ b/overwolf/src/OverwolfWindows/background/background.ts
@@ -1,5 +1,4 @@
 import { initializeDynamicSettings } from '@/logic/dynamicSettings';
-import { initializeHooks } from '@/logic/hooks';
 import { OWGameListener, OWGames, OWWindow } from '@overwolf/overwolf-api-ts';
 import { initializeHotkeyManager } from '../../logic/hotkeyManager';
 import { initializeTileCache } from '../../logic/tileCache';
@@ -158,7 +157,6 @@ if (BackgroundController.isSupported) {
 }
 
 initializeDynamicSettings();
-initializeHooks();
 initializeTileCache();
 initializeTileMarkerCache();
 initializeHotkeyManager();

--- a/overwolf/src/logic/hooks.ts
+++ b/overwolf/src/logic/hooks.ts
@@ -3,17 +3,18 @@ import { interestingFeatures } from '../OverwolfWindows/consts';
 
 export const positionUpdateRate = 1000;
 
+const listener = new OWGamesEvents({
+    onInfoUpdates: onUpdate,
+    onNewEvents: onUpdate,
+}, interestingFeatures);
+
+listener.start();
+
 type cb = (info: PlayerData) => void;
 
 const callbacks: Set<cb> = new Set();
-const isBackground = NWMM_APP_WINDOW === 'background';
-const actualRegister = isBackground ? registerEventCallbackGlobal : (overwolf.windows.getMainWindow() as any).registerEventCallbackGlobal;
 
 export function registerEventCallback(callback: cb) {
-    return actualRegister(callback);
-}
-
-function registerEventCallbackGlobal(callback: cb) {
     callbacks.add(callback);
     return () => {
         callbacks.delete(callback);
@@ -67,16 +68,4 @@ function transformData(info: any): PlayerData | undefined {
     };
 }
 
-export function initializeHooks() {
-    if (!isBackground) {
-        return;
-    }
-
-    const listener = new OWGamesEvents({
-        onInfoUpdates: onUpdate,
-        onNewEvents: onUpdate,
-    }, interestingFeatures);
-    listener.start();
-    setInterval(() => overwolf.games.events.getInfo(onUpdate), positionUpdateRate);
-    (window as any).registerEventCallbackGlobal = registerEventCallbackGlobal;
-}
+setInterval(() => overwolf.games.events.getInfo(onUpdate), positionUpdateRate);


### PR DESCRIPTION
This reverts commit d7b0c6d448020197152e24e058b7d1c35d548b1d.