### PR TITLE
Add functions to set the certain stroke and text styles

### DIFF
--- a/overwolf/src/Minimap/drawMapFriends.ts
+++ b/overwolf/src/Minimap/drawMapFriends.ts
@@ -1,6 +1,7 @@
 import { FriendData } from '@/logic/friends';
 import { toMinimapCoordinate } from '@/logic/tiles';
 import { rotateAround } from '@/logic/util';
+import setTextStyle from './setTextStyle';
 import { MapIconRendererParameters, MapRendererParameters } from './useMinimapRenderer';
 
 const sliceRotationOffset = -Math.PI / 2;
@@ -67,10 +68,8 @@ export default function drawMapFriends(params: MapRendererParameters, iconParams
         ctx.stroke();
 
         if (showText) {
-            ctx.textAlign = 'center';
+            setTextStyle(ctx, iconScale);
             ctx.font = Math.round(icon.height / 1.5) + 'px sans-serif';
-            ctx.strokeStyle = '#000';
-            ctx.fillStyle = '#fff';
 
             ctx.strokeText(friend.name, canvasPosition.x, canvasPosition.y + 15 * iconScale);
             ctx.fillText(friend.name, canvasPosition.x, canvasPosition.y + 15 * iconScale);

--- a/overwolf/src/Minimap/drawMapFriends.ts
+++ b/overwolf/src/Minimap/drawMapFriends.ts
@@ -69,8 +69,6 @@ export default function drawMapFriends(params: MapRendererParameters, iconParams
 
         if (showText) {
             setTextStyle(ctx, iconScale);
-            ctx.font = Math.round(icon.height / 1.5) + 'px sans-serif';
-
             ctx.strokeText(friend.name, canvasPosition.x, canvasPosition.y + 15 * iconScale);
             ctx.fillText(friend.name, canvasPosition.x, canvasPosition.y + 15 * iconScale);
         }

--- a/overwolf/src/Minimap/drawMapLabels.ts
+++ b/overwolf/src/Minimap/drawMapLabels.ts
@@ -4,13 +4,10 @@ import { getMarkers } from '@/logic/markers';
 import { canvasToMinimapCoordinate, getTileCoordinatesForWorldCoordinate, toMinimapCoordinate } from '@/logic/tiles';
 import { rotateAround } from '@/logic/util';
 import { LastDrawParameters } from '@/Minimap/useMinimapRenderer';
+import setTextStyle from './setTextStyle';
 
 export default function drawMapLabel(ctx: CanvasRenderingContext2D, marker: Marker, iconScale: number, center: Vector2, imgPosCorrected: Vector2, angle: number, renderAsCompass: boolean, iconHeight: number) {
-    ctx.textAlign = 'center';
-    ctx.font = Math.round(iconScale * 10) + 'px sans-serif';
-    ctx.strokeStyle = '#000';
-    ctx.fillStyle = '#fff';
-    ctx.lineWidth = 2.5;
+    setTextStyle(ctx, iconScale);
 
     const markerText = getIconName(marker.category, marker.name ?? marker.type);
 

--- a/overwolf/src/Minimap/drawMapNavigation.ts
+++ b/overwolf/src/Minimap/drawMapNavigation.ts
@@ -1,6 +1,7 @@
 import { getNavPath } from '@/logic/navigation/navigation';
 import { toMinimapCoordinate } from '@/logic/tiles';
 import { rotateAround } from '@/logic/util';
+import setLineStyle from './setLineStyle';
 import { MapRendererParameters } from './useMinimapRenderer';
 
 export default function drawMapNavigation(params: MapRendererParameters) {
@@ -36,8 +37,7 @@ export default function drawMapNavigation(params: MapRendererParameters) {
     if (path && path.length > 0) {
         const startPos = getCanvasCoord(path[0]);
 
-        ctx.strokeStyle = 'yellow';
-        ctx.lineWidth = 6;
+        setLineStyle(ctx);
         ctx.moveTo(startPos.x, startPos.y);
 
         for (let i = 1; i < path.length; i++) {

--- a/overwolf/src/Minimap/drawPlayerCoordinates.ts
+++ b/overwolf/src/Minimap/drawPlayerCoordinates.ts
@@ -1,5 +1,6 @@
 import { toMinimapCoordinate } from '@/logic/tiles';
-import {MapIconRendererParameters, MapRendererParameters} from './useMinimapRenderer';
+import setTextStyle from './setTextStyle';
+import { MapIconRendererParameters, MapRendererParameters } from './useMinimapRenderer';
 
 export default function drawPlayerCoordinates(params: MapRendererParameters, iconParams: MapIconRendererParameters) {
     const {
@@ -29,10 +30,7 @@ export default function drawPlayerCoordinates(params: MapRendererParameters, ico
         const textX = imgPosCorrected.x;
         const textY = imgPosCorrected.y + 20 * iconScale;
 
-        ctx.textAlign = 'center';
-        ctx.font = Math.round(iconScale * 10) + 'px sans-serif';
-        ctx.strokeStyle = '#000000';
-        ctx.lineWidth = 1;
+        setTextStyle(ctx, iconScale);
 
         ctx.strokeText(playerPosString, textX, textY);
         ctx.fillText(playerPosString, textX, textY);

--- a/overwolf/src/Minimap/setLineStyle.ts
+++ b/overwolf/src/Minimap/setLineStyle.ts
@@ -1,0 +1,4 @@
+export default function setLineStyle(ctx: CanvasRenderingContext2D) {
+    ctx.strokeStyle = 'yellow';
+    ctx.lineWidth = 6;
+}

--- a/overwolf/src/Minimap/setTextStyle.ts
+++ b/overwolf/src/Minimap/setTextStyle.ts
@@ -1,0 +1,7 @@
+export default function setTextStyle(ctx: CanvasRenderingContext2D, iconScale: number) {
+    ctx.textAlign = 'center';
+    ctx.font = Math.round(iconScale * 10) + 'px sans-serif';
+    ctx.strokeStyle = '#000';
+    ctx.fillStyle = '#fff';
+    ctx.lineWidth = 2.5;
+}


### PR DESCRIPTION
Extracted the style setting of certain canvas options to seperate functions as mentioned in #143 
This is done mainly for 2 reasons:
- Keep the codebase slightly cleaner by having less setup work everywhere.
- Prevent unintended interference between some settings by using a single place to set all relevant settings.