### PR TITLE
Add fine grained settings for window management

### DIFF
--- a/overwolf/src/AppSettings/pages/OverlaySettingsPage.tsx
+++ b/overwolf/src/AppSettings/pages/OverlaySettingsPage.tsx
@@ -36,6 +36,16 @@ export default function OverlaySettingsPage(props: IAppSettingsPageProps) {
                 {t('settings.overlay.shape')}
             </label>
         </div>
+        <div className={classes.setting}>
+            <label className={classes.checkbox} title={t('settings.overlay.alwaysLaunchDesktopTooltip')}>
+                <input
+                    type='checkbox'
+                    checked={settings.alwaysLaunchDesktop}
+                    onChange={e => updateSimpleSetting('alwaysLaunchDesktop', e.currentTarget.checked)}
+                />
+                {t('settings.overlay.alwaysLaunchDesktop')}
+            </label>
+        </div>
         <AdvancedSettings>
             <div className={classes.setting}>
                 <label className={classes.range} title={t('settings.overlay.opacityTooltip')}>

--- a/overwolf/src/AppSettings/pages/OverlaySettingsPage.tsx
+++ b/overwolf/src/AppSettings/pages/OverlaySettingsPage.tsx
@@ -36,6 +36,17 @@ export default function OverlaySettingsPage(props: IAppSettingsPageProps) {
                 {t('settings.overlay.shape')}
             </label>
         </div>
+        <hr />
+        <div className={classes.setting}>
+            <label className={classes.checkbox} title={t('settings.overlay.autoLaunchInGameTooltip')}>
+                <input
+                    type='checkbox'
+                    checked={settings.autoLaunchInGame}
+                    onChange={e => updateSimpleSetting('autoLaunchInGame', e.currentTarget.checked)}
+                />
+                {t('settings.overlay.autoLaunchInGame')}
+            </label>
+        </div>
         <div className={classes.setting}>
             <label className={classes.checkbox} title={t('settings.overlay.alwaysLaunchDesktopTooltip')}>
                 <input

--- a/overwolf/src/OverwolfWindows/background/background.ts
+++ b/overwolf/src/OverwolfWindows/background/background.ts
@@ -88,7 +88,6 @@ export class BackgroundController {
     }
 
     public async openWindow(window: ConcreteWindow) {
-        console.trace();
         if (this._openWindows.has(window)) {
             const windowState = await this._windows[window].getWindowState();
             if (windowState.window_state && bringToFrontWindowStates.includes(windowState.window_state)) {

--- a/overwolf/src/OverwolfWindows/background/background.ts
+++ b/overwolf/src/OverwolfWindows/background/background.ts
@@ -1,6 +1,7 @@
 import { initializeDynamicSettings } from '@/logic/dynamicSettings';
 import { initializeHooks } from '@/logic/hooks';
 import { initializeNavigation } from '@/logic/navigation/navigation';
+import { load } from '@/logic/storage';
 import UnloadingEvent from '@/logic/unloadingEvent';
 import { OWGameListener, OWGames, OWWindow } from '@overwolf/overwolf-api-ts';
 import { initializeHotkeyManager } from '../../logic/hotkeyManager';
@@ -71,7 +72,7 @@ export class BackgroundController {
     public run = async () => {
         this._NewWorldGameListener.start();
         // Decide whether to start the in-game or desktop window when running
-        const currWindow: ConcreteWindow = await this.isNewWorldRunning()
+        const currWindow: ConcreteWindow = await this.isNewWorldRunning() && !load('alwaysLaunchDesktop')
             ? 'inGame'
             : 'desktop';
         this.openWindow(currWindow);

--- a/overwolf/src/OverwolfWindows/desktop/desktop.html
+++ b/overwolf/src/OverwolfWindows/desktop/desktop.html
@@ -7,7 +7,12 @@
 </head>
 
 <body>
-  <div id="app"></div>
+  <div id="app">
+    <div
+      style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; justify-content: center; align-items: center; background: #333333; font: 32px Lato, sans-serif; color: #666666; user-select: none;">
+      <span>CptWesley's Minimap</span>
+    </div>
+  </div>
   <script>
     const NWMM_APP_WINDOW = 'desktop';
     const NWMM_APP_NAME = `<%= appName %>`;

--- a/overwolf/src/OverwolfWindows/in_game/in_game.html
+++ b/overwolf/src/OverwolfWindows/in_game/in_game.html
@@ -7,7 +7,12 @@
 </head>
 
 <body>
-  <div id="app"></div>
+  <div id="app">
+    <div
+      style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; justify-content: center; align-items: center; background: #333333; font: 32px Lato, sans-serif; color: #666666; user-select: none;">
+      <span>CptWesley's Minimap</span>
+    </div>
+  </div>
   <script>
     const NWMM_APP_WINDOW = 'inGame';
     const NWMM_APP_NAME = `<%= appName %>`;

--- a/overwolf/src/contexts/AppContext.tsx
+++ b/overwolf/src/contexts/AppContext.tsx
@@ -37,6 +37,7 @@ export function loadAppContextSettings(): AppContextSettings {
         lastKnownPosition: load('lastKnownPosition'),
         channelsServerUrl: load('channelsServerUrl'),
         showNavMesh: load('showNavMesh'),
+        alwaysLaunchDesktop: load('alwaysLaunchDesktop'),
     };
 }
 

--- a/overwolf/src/contexts/AppContext.tsx
+++ b/overwolf/src/contexts/AppContext.tsx
@@ -38,6 +38,7 @@ export function loadAppContextSettings(): AppContextSettings {
         channelsServerUrl: load('channelsServerUrl'),
         showNavMesh: load('showNavMesh'),
         alwaysLaunchDesktop: load('alwaysLaunchDesktop'),
+        autoLaunchInGame: load('autoLaunchInGame'),
     };
 }
 

--- a/overwolf/src/locales/en/common.json
+++ b/overwolf/src/locales/en/common.json
@@ -71,6 +71,8 @@
         },
         "overlay": {
             "_": "In-game overlay",
+            "alwaysLaunchDesktop": "Always launch desktop window",
+            "alwaysLaunchDesktopTooltip": "Always launches the desktop window, even if the app started because of launching the game.",
             "compassMode": "Overlay Compass Mode",
             "compassModeTooltip": "Enabling will make the player always face north and rotates the map around the player, like a classic minimap.",
             "opacity": "Overlay Opacity",

--- a/overwolf/src/locales/en/common.json
+++ b/overwolf/src/locales/en/common.json
@@ -71,8 +71,10 @@
         },
         "overlay": {
             "_": "In-game overlay",
-            "alwaysLaunchDesktop": "Always launch desktop window",
-            "alwaysLaunchDesktopTooltip": "Always launches the desktop window, even if the app started because of launching the game.",
+            "alwaysLaunchDesktop": "Always open desktop window on launch",
+            "alwaysLaunchDesktopTooltip": "Always opens the desktop window when launching CptWesley's Minimap, even if the game is running.",
+            "autoLaunchInGame": "Automatically open in-game window while this app is running",
+            "autoLaunchInGameTooltip": "Automatically opens the in-game window when the game is started and CptWesley's Minimap is running.",
             "compassMode": "Overlay Compass Mode",
             "compassModeTooltip": "Enabling will make the player always face north and rotates the map around the player, like a classic minimap.",
             "opacity": "Overlay Opacity",

--- a/overwolf/src/locales/nl/common.json
+++ b/overwolf/src/locales/nl/common.json
@@ -67,6 +67,8 @@
         },
         "overlay": {
             "_": "In-game overlay",
+            "alwaysLaunchDesktop": "Altijd het venster buiten het spel openen",
+            "alwaysLaunchDesktopTooltip": "Open altijd het venster buiten het spel, zelfs als de app gestart wordt doordat het spel geopend wordt.",
             "compassMode": "Kompasmodus overlay",
             "compassModeTooltip": "Zorgt ervoor dat de speler altijd richting het noorden kijkt, en draait de kaart mee, zoals een klassieke minimap.",
             "opacity": "Ondoorzichtigheid overlay",

--- a/overwolf/src/locales/nl/common.json
+++ b/overwolf/src/locales/nl/common.json
@@ -68,7 +68,9 @@
         "overlay": {
             "_": "In-game overlay",
             "alwaysLaunchDesktop": "Altijd het venster buiten het spel openen",
-            "alwaysLaunchDesktopTooltip": "Open altijd het venster buiten het spel, zelfs als de app gestart wordt doordat het spel geopend wordt.",
+            "alwaysLaunchDesktopTooltip": "Open altijd het venster buiten het spel wanneer CptWesley's Minimap gestart wordt, zelfs als het spel actief is.",
+            "autoLaunchInGame": "Automatisch het in-game venster openen als deze app actief is",
+            "autoLaunchInGameTooltip": "Open automatisch het in-game venster wanneer het spel geopend wordt en de CptWesley's Minimap actief is.",
             "compassMode": "Kompasmodus overlay",
             "compassModeTooltip": "Zorgt ervoor dat de speler altijd richting het noorden kijkt, en draait de kaart mee, zoals een klassieke minimap.",
             "opacity": "Ondoorzichtigheid overlay",

--- a/overwolf/src/logic/storage.ts
+++ b/overwolf/src/logic/storage.ts
@@ -36,6 +36,7 @@ export const simpleStorageDefaultSettings = {
     lastKnownPosition: debugLocations.default,
     channelsServerUrl: '',
     showNavMesh: false,
+    alwaysLaunchDesktop: false,
 };
 
 {

--- a/overwolf/src/logic/storage.ts
+++ b/overwolf/src/logic/storage.ts
@@ -37,6 +37,7 @@ export const simpleStorageDefaultSettings = {
     channelsServerUrl: '',
     showNavMesh: false,
     alwaysLaunchDesktop: false,
+    autoLaunchInGame: true,
 };
 
 {

--- a/overwolf/webpack.config.js
+++ b/overwolf/webpack.config.js
@@ -39,6 +39,10 @@ module.exports = (env, argv) => {
                         test: /[\\/]node_modules[\\/]/,
                         reuseExistingChunk: true,
                     },
+                    roadGraphData: {
+                        test: /roadGraphData\.js/,
+                        reuseExistingChunk: true,
+                    }
                 },
             },
         },


### PR DESCRIPTION
Adds additional settings for controlling if

- The desktop window is shown when the app is launched _because_ of the game launching.
- The in-game window is shown automatically, when the game launches while Minimap is running.

The in-game window is always shown if the app is launched due to the game launching.

![image](https://user-images.githubusercontent.com/17430732/139908997-32baf0fd-e76c-4b79-8a89-4ae1f29410c5.png)
