### PR TITLE
Api rotation

### DIFF
--- a/overwolf/src/AppSettings/pages/WindowSettingsPage.tsx
+++ b/overwolf/src/AppSettings/pages/WindowSettingsPage.tsx
@@ -178,17 +178,29 @@ export default function WindowSettingsPage(props: IAppSettingsPageProps) {
                 {t('settings.window.resamplingRate')}
             </label>
         </div>
-        <div className={classes.setting} title={t('settings.window.showPlayerCoordinatesTooltip')}>
-            <label className={classes.checkbox}>
-                <input
-                    type='checkbox'
-                    checked={settings.showPlayerCoordinates}
-                    onChange={e => updateSimpleSetting('showPlayerCoordinates', e.currentTarget.checked)}
-                />
-                {t('settings.window.showPlayerCoordinates')}
+        <div className={classes.setting}>
+            <label className={classes.select} title={t('settings.window.rotationSourceTooltip')}>
+                <select
+                    value={settings.rotationSource}
+                    onChange={e => updateSimpleSetting('rotationSource', e.currentTarget.value as RotationSource)}
+                >
+                    <option value='api'>{t('settings.window.rotationSourceApi')}</option>
+                    <option value='computed'>{t('settings.window.rotationSourceComputed')}</option>
+                </select>
+                {t('settings.window.rotationSource')}
             </label>
         </div>
         <AdvancedSettings>
+            <div className={classes.setting} title={t('settings.window.showPlayerCoordinatesTooltip')}>
+                <label className={classes.checkbox}>
+                    <input
+                        type='checkbox'
+                        checked={settings.showPlayerCoordinates}
+                        onChange={e => updateSimpleSetting('showPlayerCoordinates', e.currentTarget.checked)}
+                    />
+                    {t('settings.window.showPlayerCoordinates')}
+                </label>
+            </div>
             <div className={classes.setting} title={t('settings.window.showNavMeshTooltip')}>
                 <label className={classes.checkbox}>
                     <input

--- a/overwolf/src/Global.d.ts
+++ b/overwolf/src/Global.d.ts
@@ -53,7 +53,7 @@ declare type IconSettings = {
 
 declare type PlayerData = {
     position: Vector3,
-    rotation: Vector3,
+    rotation: number,
     compass: string,
     map: string | undefined,
     name: string | undefined,
@@ -64,6 +64,11 @@ type AnimationInterpolation =
     | 'none'
     | 'cosine'
     | 'linear'
+    ;
+
+type RotationSource =
+    | 'api'
+    | 'computed'
     ;
 
 declare type GraphNode = {

--- a/overwolf/src/Minimap.tsx
+++ b/overwolf/src/Minimap.tsx
@@ -101,14 +101,14 @@ export default function Minimap(props: IProps) {
         zoomBy,
     } = useMinimapRenderer(canvas, hoverLabelCanvas);
 
-    function setPosition(pos: Vector2) {
+    function setPosition(pos: Vector2, rotation: number) {
         if (appContext.settings.shareLocation) {
             const sharedLocation = updateFriendLocation(appContext.settings.channelsServerUrl, playerName.current, pos);
             sharedLocation.then(setFriends);
         }
 
         store('lastKnownPosition', pos);
-        setPlayerPosition(pos);
+        setPlayerPosition(pos, rotation);
     }
 
     function setFriends(channels: undefined | FriendData[]) {
@@ -268,7 +268,7 @@ export default function Minimap(props: IProps) {
         (window as any).setFriends = setFriends;
 
         const callbackUnregister = registerEventCallback(info => {
-            setPosition(info.position);
+            setPosition(info.position, info.rotation);
 
             if (info.name) {
                 playerName.current = info.name;

--- a/overwolf/src/Minimap/useMinimapRenderer.ts
+++ b/overwolf/src/Minimap/useMinimapRenderer.ts
@@ -206,12 +206,12 @@ export default function useMinimapRenderer(canvas: React.RefObject<HTMLCanvasEle
         drawWithInterpolationRef.current(force);
     }
 
-    function setPlayerPosition(pos: Vector2) {
+    function setPlayerPosition(pos: Vector2, rotation: number) {
         if (pos.x === currentPlayerPosition.current.x && pos.y === currentPlayerPosition.current.y) {
             return;
         }
 
-        currentPlayerAngle.current = getAngle(lastPlayerPosition.current, currentPlayerPosition.current);
+        currentPlayerAngle.current = appContext.settings.rotationSource === 'computed' ? getAngle(lastPlayerPosition.current, currentPlayerPosition.current) : rotation;
         lastPositionUpdate.current = performance.now();
         lastPlayerPosition.current = currentPlayerPosition.current;
         currentPlayerPosition.current = pos;

--- a/overwolf/src/Minimap/useMinimapRenderer.ts
+++ b/overwolf/src/Minimap/useMinimapRenderer.ts
@@ -225,7 +225,7 @@ export default function useMinimapRenderer(canvas: React.RefObject<HTMLCanvasEle
             const predictedPosition = predictVector(lastPlayerPosition.current, currentPlayerPosition.current);
             updateInterpolatedPlayerPosition(predictedPosition, updateTime);
         }
-        updateInterpolatedAngle(getAngle(lastPlayerPosition.current, currentPlayerPosition.current), updateTime);
+        updateInterpolatedAngle(currentPlayerAngle.current, updateTime);
 
         redraw(true);
     }

--- a/overwolf/src/contexts/AppContext.tsx
+++ b/overwolf/src/contexts/AppContext.tsx
@@ -39,7 +39,7 @@ export function loadAppContextSettings(): AppContextSettings {
         showNavMesh: load('showNavMesh'),
         alwaysLaunchDesktop: load('alwaysLaunchDesktop'),
         autoLaunchInGame: load('autoLaunchInGame'),
-        rotationSource: load('rotationSouce'),
+        rotationSource: load('rotationSource'),
     };
 }
 

--- a/overwolf/src/contexts/AppContext.tsx
+++ b/overwolf/src/contexts/AppContext.tsx
@@ -39,6 +39,7 @@ export function loadAppContextSettings(): AppContextSettings {
         showNavMesh: load('showNavMesh'),
         alwaysLaunchDesktop: load('alwaysLaunchDesktop'),
         autoLaunchInGame: load('autoLaunchInGame'),
+        rotationSource: load('rotationSouce'),
     };
 }
 

--- a/overwolf/src/locales/en/common.json
+++ b/overwolf/src/locales/en/common.json
@@ -67,7 +67,11 @@
             "resamplingRate": "Upsampling factor",
             "resamplingRateTooltip": "The number of samples taken when performing inter/extra-polation. A higher value will give a smoother experience, but has worse performance.",
             "showNavMesh": "Show Nagivation Mesh",
-            "showNavMeshTooltip": "Shows the navigation mesh. Useful for debugging the navigation system. Causes a heavy performance hit. Don't enable unless necessary."
+            "showNavMeshTooltip": "Shows the navigation mesh. Useful for debugging the navigation system. Causes a heavy performance hit. Don't enable unless necessary.",
+            "rotationSource": "Rotation Data",
+            "rotationSourceTooltip": "Determines which source of rotation data is used when rendering player on the minimap.",
+            "rotationSourceApi": "Character Direction",
+            "rotationSourceComputed": "Movement Direction"
         },
         "overlay": {
             "_": "In-game overlay",

--- a/overwolf/src/logic/hooks.ts
+++ b/overwolf/src/logic/hooks.ts
@@ -44,11 +44,7 @@ function transformData(info: any): PlayerData | undefined {
         z: parseFloat(locationParts[5]),
     };
 
-    const rotation = {
-        x: parseFloat(locationParts[7]),
-        y: parseFloat(locationParts[9]),
-        z: parseFloat(locationParts[11]),
-    };
+    const rotation = -(parseFloat(locationParts[11]) - 90) * Math.PI / 180;
 
     const compass = locationParts[13].trim();
 

--- a/overwolf/src/logic/storage.ts
+++ b/overwolf/src/logic/storage.ts
@@ -38,6 +38,7 @@ export const simpleStorageDefaultSettings = {
     showNavMesh: false,
     alwaysLaunchDesktop: false,
     autoLaunchInGame: true,
+    rotationSource: 'api' as RotationSource,
 };
 
 {
@@ -82,6 +83,7 @@ export const scopedSettings: (keyof SimpleStorageSetting)[] = [
     'extrapolateLocation',
     'resamplingRate',
     'showNavMesh',
+    'rotationSource',
 ];
 
 export const iconSettingStorageScope = 'icon';

--- a/overwolf/src/logic/util.ts
+++ b/overwolf/src/logic/util.ts
@@ -11,7 +11,7 @@ export function getNumberInterpolator(animationInterpolation: AnimationInterpola
 
 export function getAngleInterpolator(animationInterpolation: AnimationInterpolation): Interpolator<number> {
     switch (animationInterpolation) {
-        case 'cosine': return interpolateAngleCosine;
+        case 'cosine': return interpolateAngleLinear;
         case 'linear': return interpolateAngleLinear;
         case 'none': return undefined;
     }

--- a/overwolf/src/logic/util.ts
+++ b/overwolf/src/logic/util.ts
@@ -79,12 +79,6 @@ export function interpolateVectorsCosine(start: Vector2, end: Vector2, percentag
     };
 }
 
-export function interpolateAngleCosine(start: number, end: number, percentage: number) {
-    const mu = computeCosineInterpolationMu(percentage);
-    const bestEnd = correctEndAngle(start, end);
-    return start * (1 - mu) + bestEnd * mu;
-}
-
 function correctEndAngle(start: number, end: number) {
     const alternativeEnd1 = end - Math.PI * 2;
     const alternativeEnd2 = end + Math.PI * 2;


### PR DESCRIPTION
## Changes
- Reverted the interpolation settings for angles to always use linear. Since cosine interpolation can make the angle interpolation become very aggressive for small changes.
- Changed the rotation used by default to be the rotation retrieved from the API. (API seems to give up-to-date data now)
- Added option to revert back to movement-based angles if people prefer that.