### PR TITLE
Add feature flag and render custom paths behind feature flag

### DIFF
--- a/overwolf/package.json
+++ b/overwolf/package.json
@@ -49,6 +49,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/react-fontawesome": "^0.1.15",
+    "@types/geojson": "^7946.0.8",
     "clsx": "^1.1.1",
     "crypto-js": "^4.1.1",
     "dexie": "^3.0.3",

--- a/overwolf/src/AppSettings/AppSettings.tsx
+++ b/overwolf/src/AppSettings/AppSettings.tsx
@@ -13,6 +13,7 @@ import FriendSettingsPage from './pages/FriendChannelsSettingsPage';
 import IconSettingsPage from './pages/IconSettingsPage';
 import OverlaySettingsPage from './pages/OverlaySettingsPage';
 import WindowSettingsPage from './pages/WindowSettingsPage';
+import PreviewFeaturesSettingsPage from './pages/PreviewFeaturesSettingsPage';
 
 interface IProps {
     visible: boolean;
@@ -178,6 +179,7 @@ const settingsPageMap = {
     overlay: OverlaySettingsPage,
     icon: IconSettingsPage,
     friendChannels: FriendSettingsPage,
+    previewFeatures: PreviewFeaturesSettingsPage,
 } as const;
 
 const settingsPages: (keyof typeof settingsPageMap)[] = [
@@ -185,6 +187,7 @@ const settingsPages: (keyof typeof settingsPageMap)[] = [
     'overlay',
     'icon',
     'friendChannels',
+    'previewFeatures',
 ];
 
 export default function AppSettings(props: IProps) {
@@ -240,6 +243,19 @@ export default function AppSettings(props: IProps) {
                     >
                         {t(`settings.${p}._`)}
                     </button>
+                )}
+                {previewSettingsPages.map(p => {
+                    const page = p[0];
+                    const shouldRender = p[1](context.settings);
+                    return shouldRender ? (
+                        <button key={page}
+                            className={clsx(classes.navItem, page === currentPage && classes.navItemActive)}
+                            onClick={() => setCurrentPage(page)}
+                        >
+                            {t(`settings.${p[0]}._`)}
+                        </button>
+                    ) : <></>;
+                }
                 )}
             </nav>
             <div className={classes.content}>

--- a/overwolf/src/AppSettings/AppSettings.tsx
+++ b/overwolf/src/AppSettings/AppSettings.tsx
@@ -14,6 +14,7 @@ import IconSettingsPage from './pages/IconSettingsPage';
 import OverlaySettingsPage from './pages/OverlaySettingsPage';
 import WindowSettingsPage from './pages/WindowSettingsPage';
 import PreviewFeaturesSettingsPage from './pages/PreviewFeaturesSettingsPage';
+import FeatureCollectionPage, {featureCollectionPageEnabled} from './pages/FeatureCollectionPage';
 
 interface IProps {
     visible: boolean;
@@ -180,6 +181,7 @@ const settingsPageMap = {
     icon: IconSettingsPage,
     friendChannels: FriendSettingsPage,
     previewFeatures: PreviewFeaturesSettingsPage,
+    featureCollection: FeatureCollectionPage,
 } as const;
 
 const settingsPages: (keyof typeof settingsPageMap)[] = [
@@ -188,6 +190,10 @@ const settingsPages: (keyof typeof settingsPageMap)[] = [
     'icon',
     'friendChannels',
     'previewFeatures',
+];
+
+const previewSettingsPages: [keyof typeof settingsPageMap, (settings: AppContextSettings) => Boolean][] = [
+    ['featureCollection', featureCollectionPageEnabled],
 ];
 
 export default function AppSettings(props: IProps) {

--- a/overwolf/src/AppSettings/pages/FeatureCollectionPage.tsx
+++ b/overwolf/src/AppSettings/pages/FeatureCollectionPage.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import { FeatureCollection } from 'geojson';
+import { IAppSettingsPageProps } from '@/AppSettings/AppSettings';
+import { useTranslation } from 'react-i18next';
+import { AppContextSettings } from '@/contexts/AppContext';
+import {makeStyles} from '@/theme';
+import clsx from 'clsx';
+
+const useStyles = makeStyles()(() => ({
+    dataText: {
+        whiteSpace: 'pre-line',
+        wordBreak: 'break-word',
+        margin: '5px 0',
+        height: '70%',
+        width: '80%',
+    },
+}));
+
+export const featureCollectionPageEnabled = (appSettings: AppContextSettings) =>  {
+    return appSettings.enabledPreviewFunctionailities.includes('feature-collection-render');
+};
+
+export default function FeatureCollectionPage (props: IAppSettingsPageProps) {
+    const {
+        settings,
+        updateSettings,
+    } = props;
+
+    const { classes } = useStyles();
+    const { t } = useTranslation();
+
+    const [rawFeatureCollection, setRawFeatureCollection] = useState<string>(
+        JSON.stringify(settings.featureCollection, null, 2)
+    );
+    const [parseError, setParseError] = useState(false);
+
+    const onChange = (event: React.FormEvent<HTMLTextAreaElement>) => {
+        const newRawFeatureCollection = event.currentTarget.value;
+        setRawFeatureCollection(newRawFeatureCollection);
+        try {
+            // TODO: Guard against invalid output with proper geojson parser.
+            updateSettings(
+                {
+                    featureCollection: JSON.parse(newRawFeatureCollection) as FeatureCollection,
+                }
+            );
+            setParseError(false);
+        } catch (error) {
+            setParseError(true);
+        }
+    };
+
+    return (
+        <>
+            <textarea className={clsx(classes.dataText)} value={rawFeatureCollection} onChange={onChange} />
+            {parseError && <div>{t('settings.featureCollection.inavlidGeoJSON')}</div>}
+        </>
+    );
+
+}

--- a/overwolf/src/AppSettings/pages/PreviewFeaturesSettingsPage.tsx
+++ b/overwolf/src/AppSettings/pages/PreviewFeaturesSettingsPage.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { IAppSettingsPageProps } from '../AppSettings';
+import { useSharedSettingsStyles } from '../sharedSettingStyles';
+
+export default function PreviewFeaturesSettingsPage(props: IAppSettingsPageProps) {
+    const {
+        settings,
+        updateSettings,
+    } = props;
+    const { classes } = useSharedSettingsStyles();
+    const { t } = useTranslation();
+
+    return <>
+        <div className={classes.setting}>
+            <label className={classes.checkbox} title={t('settings.previewFeatures.featureCollectionRender')}>
+                <input
+                    type='checkbox'
+                    checked={settings.enabledPreviewFunctionailities.includes('feature-collection-render')}
+                    onChange={e => {
+                        if (e.currentTarget.checked) {
+                            updateSettings(
+                                {
+                                    enabledPreviewFunctionailities: settings.enabledPreviewFunctionailities.concat(['feature-collection-render']),
+                                }
+                            );
+
+                        } else {
+                            updateSettings(
+                                {
+                                    enabledPreviewFunctionailities:
+                                        settings.enabledPreviewFunctionailities = settings.enabledPreviewFunctionailities.filter(
+                                            (f) => f !== 'feature-collection-render'
+                                        ),
+                                }
+                            );
+                        }
+                    }}
+                />
+                {t('settings.previewFeatures.featureCollectionRender')}
+            </label>
+        </div>
+    </>;
+}

--- a/overwolf/src/Global.d.ts
+++ b/overwolf/src/Global.d.ts
@@ -75,3 +75,8 @@ declare type GraphNode = {
     position: Vector2,
     neighbors: number[],
 }
+
+declare type featureProperties = {
+    strokeStyle?: string,
+    lineWidth?: number,
+}

--- a/overwolf/src/Minimap/drawFeatureCollection.ts
+++ b/overwolf/src/Minimap/drawFeatureCollection.ts
@@ -1,0 +1,60 @@
+import { MapIconRendererParameters, MapRendererParameters } from './useMinimapRenderer';
+import {Feature, LineString} from 'geojson';
+import {worldCoordinateToCanvas} from '@/logic/tiles';
+import {rotateAround} from '@/logic/util';
+
+const drawLineString = (params: MapRendererParameters, iconParams: MapIconRendererParameters, lineString: LineString, properties: featureProperties) => {
+    const { context, mapCenterPosition, zoomLevel, renderAsCompass, center, mapAngle} = params;
+
+    context.beginPath();
+    let pointIndex = 0;
+    for (const coor of lineString.coordinates) {
+        const pointPos: Vector2 = {x: coor[0], y: coor[1]};
+        const position = worldCoordinateToCanvas(
+            pointPos,
+            mapCenterPosition,
+            zoomLevel,
+            context.canvas.width,
+            context.canvas.height,
+        );
+
+        const canvasPosition = renderAsCompass
+            ? rotateAround(center, position, -mapAngle)
+            : position;
+        if (pointIndex === 0) {
+            context.moveTo(canvasPosition.x, canvasPosition.y);
+        } else {
+            context.lineTo(canvasPosition.x, canvasPosition.y);
+        }
+        pointIndex++;
+    }
+    // Reset to default style
+    context.strokeStyle = '#000000';
+    context.lineWidth = 1;
+
+    if (properties?.strokeStyle !== undefined) {
+        context.strokeStyle = properties?.strokeStyle;
+    }
+    if (properties?.lineWidth !== undefined) {
+        context.lineWidth = properties?.lineWidth;
+    }
+    context.stroke();
+
+};
+
+export default function drawFeatureCollection(params: MapRendererParameters, iconParams: MapIconRendererParameters, features: Feature[]) {
+
+    for (const feature of features) {
+        if (feature.geometry.type !== 'LineString') {
+            console.warn('Only `LineString` feature is supported at the moment');
+        } else {
+            drawLineString(
+                params,
+                iconParams,
+                feature.geometry,
+                feature.properties as featureProperties,
+            );
+        }
+    }
+}
+

--- a/overwolf/src/Minimap/drawPlayerCoordinates.ts
+++ b/overwolf/src/Minimap/drawPlayerCoordinates.ts
@@ -1,4 +1,5 @@
 import { worldCoordinateToCanvas } from '@/logic/tiles';
+import { rotateAround } from '@/logic/util';
 import setTextStyle from './setTextStyle';
 import { MapIconRendererParameters, MapRendererParameters } from './useMinimapRenderer';
 
@@ -9,6 +10,9 @@ export default function drawPlayerCoordinates(params: MapRendererParameters, ico
         mapCenterPosition,
         zoomLevel,
         showPlayerCoordinates,
+        renderAsCompass,
+        mapAngle,
+        center,
     } = params;
 
     const {
@@ -26,9 +30,12 @@ export default function drawPlayerCoordinates(params: MapRendererParameters, ico
             ctx.canvas.width,
             ctx.canvas.height,
         );
+        const canvasPosition = renderAsCompass
+            ? rotateAround(center, position, -mapAngle)
+            : position;
 
-        const textX = position.x;
-        const textY = position.y + 20 * iconScale;
+        const textX = canvasPosition.x;
+        const textY = canvasPosition.y + 20 * iconScale;
 
         setTextStyle(ctx, iconScale);
 

--- a/overwolf/src/Minimap/useMinimapRenderer.ts
+++ b/overwolf/src/Minimap/useMinimapRenderer.ts
@@ -17,6 +17,7 @@ import drawNavMesh from './drawNavMesh';
 import drawPlayerCoordinates from './drawPlayerCoordinates';
 import { angleInterpolationTime, locationInterpolationTime, mapFastZoom, mapSlowZoom, tooLargeDistance, townZoomDistance } from './mapConstants';
 import { useInterpolation } from './useInterpolation';
+import drawFeatureCollection from "@/Minimap/drawFeatureCollection";
 
 export type MapRendererParameters = {
     context: CanvasRenderingContext2D,
@@ -29,6 +30,7 @@ export type MapRendererParameters = {
     zoomLevel: number,
     showPlayerCoordinates: boolean,
     showNavMesh: boolean,
+    showFeatureCollection: boolean,
 }
 
 export type MapIconRendererParameters = {
@@ -151,6 +153,7 @@ export default function useMinimapRenderer(canvas: React.RefObject<HTMLCanvasEle
             zoomLevel,
             showPlayerCoordinates: appContext.settings.showPlayerCoordinates,
             showNavMesh: appContext.settings.showNavMesh,
+            showFeatureCollection: appContext.settings.enabledPreviewFunctionailities.includes('feature-collection-render'),
         };
 
         const toDraw = drawMapTiles(mapRendererParameters);
@@ -181,6 +184,8 @@ export default function useMinimapRenderer(canvas: React.RefObject<HTMLCanvasEle
         drawMapPlayer(mapRendererParameters, mapIconRendererParameters);
 
         drawPlayerCoordinates(mapRendererParameters, mapIconRendererParameters);
+
+        drawFeatureCollection(mapRendererParameters, mapIconRendererParameters, appContext.settings.featureCollection.features);
 
         lastDrawParameters.current = {
             mapRendererParams: mapRendererParameters,
@@ -276,6 +281,7 @@ export default function useMinimapRenderer(canvas: React.RefObject<HTMLCanvasEle
         appContext.settings.animationInterpolation,
         appContext.settings.compassMode,
         appContext.settings.extrapolateLocation,
+        appContext.settings.featureCollection,
         appContext.settings.iconScale,
         appContext.settings.iconSettings,
         appContext.settings.showNavMesh,

--- a/overwolf/src/Minimap/useMinimapRenderer.ts
+++ b/overwolf/src/Minimap/useMinimapRenderer.ts
@@ -17,7 +17,7 @@ import drawNavMesh from './drawNavMesh';
 import drawPlayerCoordinates from './drawPlayerCoordinates';
 import { angleInterpolationTime, locationInterpolationTime, mapFastZoom, mapSlowZoom, tooLargeDistance, townZoomDistance } from './mapConstants';
 import { useInterpolation } from './useInterpolation';
-import drawFeatureCollection from "@/Minimap/drawFeatureCollection";
+import drawFeatureCollection from '@/Minimap/drawFeatureCollection';
 
 export type MapRendererParameters = {
     context: CanvasRenderingContext2D,

--- a/overwolf/src/contexts/AppContext.tsx
+++ b/overwolf/src/contexts/AppContext.tsx
@@ -41,6 +41,7 @@ export function loadAppContextSettings(): AppContextSettings {
         autoLaunchInGame: load('autoLaunchInGame'),
         rotationSource: load('rotationSource'),
         enabledPreviewFunctionailities: load('enabledPreviewFunctionailities'),
+        featureCollection: load('featureCollection'),
     };
 }
 

--- a/overwolf/src/contexts/AppContext.tsx
+++ b/overwolf/src/contexts/AppContext.tsx
@@ -40,6 +40,7 @@ export function loadAppContextSettings(): AppContextSettings {
         alwaysLaunchDesktop: load('alwaysLaunchDesktop'),
         autoLaunchInGame: load('autoLaunchInGame'),
         rotationSource: load('rotationSource'),
+        enabledPreviewFunctionailities: load('enabledPreviewFunctionailities'),
     };
 }
 

--- a/overwolf/src/locales/en/common.json
+++ b/overwolf/src/locales/en/common.json
@@ -118,6 +118,8 @@
             "featureCollectionRender": "Render Feature Collection.",
             "featureCollectionEdit": "Edit Feature Collection."
         },
+        "featureCollection": {
+            "_": "Feature collection"
         }
     }
 }

--- a/overwolf/src/locales/en/common.json
+++ b/overwolf/src/locales/en/common.json
@@ -112,6 +112,12 @@
             "customServerUrlTooltip": "The URL of the server channels endpoint that you want to connect to. Leave blank for default server.",
             "friendId": "Your friend ID is '{{id}}'.",
             "regenerateId": "Generate a new friend ID. Does not affect operations, only the ID that the server receives."
+        },
+        "previewFeatures": {
+            "_": "Functionaility previews",
+            "featureCollectionRender": "Render Feature Collection.",
+            "featureCollectionEdit": "Edit Feature Collection."
+        },
         }
     }
 }

--- a/overwolf/src/logic/storage.ts
+++ b/overwolf/src/logic/storage.ts
@@ -1,4 +1,33 @@
 import { ConcreteWindow } from '../OverwolfWindows/consts';
+import {FeatureCollection} from "geojson";
+
+export const debugFeatureCollections = {
+    weaversFen: JSON.parse(`
+        {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": {
+                        "legend": "Testing",
+                        "strokeStyle": "#EBA5AB",
+                        "lineWidth": 5
+                    },
+                    "geometry": {
+                        "type": "LineString",
+                        "coordinates": [
+                            [ 11540.99, 5444.16 ],
+                            [ 11571, 5453.48 ],
+                            [ 11575, 5431 ],
+                            [ 11507, 5404 ]
+                        ]
+                    }
+                }
+            ]
+        }
+    `) as FeatureCollection,
+};
+
 
 const debugLocations = {
     default: { x: 7728.177, y: 1988.299 } as Vector2,
@@ -44,6 +73,7 @@ export const simpleStorageDefaultSettings = {
     autoLaunchInGame: true,
     rotationSource: 'api' as RotationSource,
     enabledPreviewFunctionailities: [] as PreviewFunctionaility[],
+    featureCollection: debugFeatureCollections.weaversFen,
 };
 
 {

--- a/overwolf/src/logic/storage.ts
+++ b/overwolf/src/logic/storage.ts
@@ -15,6 +15,10 @@ const deprecatedInterpolationKey = 'interpolation';
 
 const deprecatedFriendServerUrlKey = 'friendServerUrl';
 
+type PreviewFunctionaility =
+    | 'feature-collection-render'
+    | 'feature-collection-edit'
+
 export const simpleStorageDefaultSettings = {
     showHeader: true,
     showToolbar: NWMM_APP_WINDOW === 'desktop',
@@ -39,6 +43,7 @@ export const simpleStorageDefaultSettings = {
     alwaysLaunchDesktop: false,
     autoLaunchInGame: true,
     rotationSource: 'api' as RotationSource,
+    enabledPreviewFunctionailities: [] as PreviewFunctionaility[],
 };
 
 {

--- a/overwolf/src/logic/storage.ts
+++ b/overwolf/src/logic/storage.ts
@@ -1,5 +1,5 @@
 import { ConcreteWindow } from '../OverwolfWindows/consts';
-import {FeatureCollection} from "geojson";
+import {FeatureCollection} from 'geojson';
 
 export const debugFeatureCollections = {
     weaversFen: JSON.parse(`
@@ -27,7 +27,6 @@ export const debugFeatureCollections = {
         }
     `) as FeatureCollection,
 };
-
 
 const debugLocations = {
     default: { x: 7728.177, y: 1988.299 } as Vector2,

--- a/overwolf/yarn.lock
+++ b/overwolf/yarn.lock
@@ -236,6 +236,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.50.tgz#1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83"
   integrity sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
 
+"@types/geojson@^7946.0.8":
+  version "7946.0.8"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.8.tgz#30744afdb385e2945e22f3b033f897f76b1f12ca"
+  integrity sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA==
+
 "@types/glob@^7.1.1":
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.4.tgz#ea59e21d2ee5c517914cb4bc8e4153b99e566672"


### PR DESCRIPTION
- Add feature preview functionaility;
- Add custom paths rendering behind new feature preview functionaility;
- Small fix re. player position rendering while in compass mode and panned;

Screenshots:
Feature flag page
![image](https://user-images.githubusercontent.com/8895126/141651902-c3044d8f-78d5-4517-8d5a-ea192d584846.png)
After enabling the flag
![image](https://user-images.githubusercontent.com/8895126/141651933-fd37fbd3-f14c-4ca6-bf36-9dd39d5beab2.png)
Inputting an example geojson blob near monach's bluff [1]
![image](https://user-images.githubusercontent.com/8895126/141651952-1101b897-6368-457d-b2b5-9b1f81d6acf8.png)
Path shown as two distinct segments
![image](https://user-images.githubusercontent.com/8895126/141651988-4868450c-16c4-4ad7-b4a4-6fc28a80cbb5.png)
Doesn't interfere with nav
![image](https://user-images.githubusercontent.com/8895126/141652000-abd84462-bef9-4221-bf94-ff2629331d98.png)
Nor does it interfere with text
![image](https://user-images.githubusercontent.com/8895126/141652011-11d9efde-20d3-42a4-977c-a07efc8cbcfe.png)
Line size do not respect icon size by deisgn
![image](https://user-images.githubusercontent.com/8895126/141652022-94fd8888-923e-4046-ba4b-9693ce63c82c.png)


[1] - geojson blob near monach's bluff
```json
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "properties": {
        "legend": "Testing",
        "strokeStyle": "#EBA5AB",
        "lineWidth": 10
      },
      "geometry": {
        "type": "LineString",
        "coordinates": [
          [
            7307,3608
            
          ],
          [
            7390,3597
            
          ],
          [
            7420,3587
            
          ],
          [
            7417,3550
            
          ]
        ]
      }
    },
    {
      "type": "Feature",
      "properties": {
        "legend": "Testing",
        "strokeStyle": "#B3C8EA",
        "lineWidth": 5
      },
      "geometry": {
        "type": "LineString",
        "coordinates": [
          [
            7407,3608
            
          ],
          [
            7490,3597
            
          ],
          [
            7520,3587
            
          ],
          [
            7517,3550
          ]
        ]
      }
    }
  ]
}
```
